### PR TITLE
[gitpod] Fix color theme

### DIFF
--- a/extensions/gitpod/package.json
+++ b/extensions/gitpod/package.json
@@ -22,14 +22,6 @@
   ],
   "main": "./out/extension.js",
   "contributes": {
-    "themes": [
-      {
-        "id": "Gitpod Light",
-        "label": "%themeLabel%",
-        "uiTheme": "vs",
-        "path": "./themes/gitpod-light-color-theme.json"
-      }
-    ],
     "commands": [
       {
         "command": "gitpod.stop.ws",

--- a/extensions/gitpod/package.nls.json
+++ b/extensions/gitpod/package.nls.json
@@ -1,7 +1,6 @@
 {
 	"displayName": "Gitpod",
 	"description": "Gitpod Integration Support",
-	"themeLabel": "Gitpod Light",
 	"openDashboard": "Gitpod: Open Dashboard",
 	"openAccessControl": "Gitpod: Open Access Control",
 	"openSettings": "Gitpod: Open Settings",

--- a/extensions/theme-defaults/package.json
+++ b/extensions/theme-defaults/package.json
@@ -14,6 +14,18 @@
   "contributes": {
     "themes": [
       {
+        "id": "Gitpod Dark",
+        "label": "%gitpodDark%",
+        "uiTheme": "vs-dark",
+        "path": "./themes/gitpod-dark-color-theme.json"
+      },
+      {
+        "id": "Gitpod Light",
+        "label": "%gitpodLight%",
+        "uiTheme": "vs",
+        "path": "./themes/gitpod-light-color-theme.json"
+      },
+      {
         "id": "Default Dark+",
         "label": "%darkPlusColorThemeLabel%",
         "uiTheme": "vs-dark",

--- a/extensions/theme-defaults/package.nls.json
+++ b/extensions/theme-defaults/package.nls.json
@@ -1,6 +1,8 @@
 {
 	"displayName": "Default Themes",
 	"description": "The default Visual Studio light and dark themes",
+	"gitpodDark": "Gitpod Dark",
+	"gitpodLight": "Gitpod Light",
 	"darkPlusColorThemeLabel": "Dark+ (default dark)",
 	"lightPlusColorThemeLabel": "Light+ (default light)",
 	"darkColorThemeLabel": "Dark (Visual Studio)",

--- a/extensions/theme-defaults/themes/gitpod-dark-color-theme.json
+++ b/extensions/theme-defaults/themes/gitpod-dark-color-theme.json
@@ -1,0 +1,13 @@
+{
+	"name": "Gitpod Dark",
+	"include": "./dark_plus.json",
+	"colors": {
+		"statusBarItem.remoteBackground": "#292524",
+        "statusBarItem.remoteForeground": "#f9f9f9",
+        "statusBar.background": "#FF8A00",
+        "statusBar.noFolderBackground": "#FF8A00",
+        "statusBar.debuggingBackground": "#FF8A00",
+        "button.background": "#FF8A00",
+        "button.foreground": "#ffffff"
+	}
+}

--- a/extensions/theme-defaults/themes/gitpod-light-color-theme.json
+++ b/extensions/theme-defaults/themes/gitpod-light-color-theme.json
@@ -1,5 +1,6 @@
 {
 	"name": "Gitpod Light",
+	"include": "./light_plus.json",
 	"colors": {
 		"statusBarItem.remoteBackground": "#292524",
         "statusBarItem.remoteForeground": "#f9f9f9",


### PR DESCRIPTION
We need to inherit existing themes to keep maintenance low. Moved the
themes to the default theme extension to be able to import existing
token definitions.