### PR TITLE
[gitpod] Update dark theme

### DIFF
--- a/extensions/theme-defaults/themes/gitpod-dark-color-theme.json
+++ b/extensions/theme-defaults/themes/gitpod-dark-color-theme.json
@@ -19,7 +19,7 @@
         "list.activeSelectionForeground": "#F3F3F3",
         "list.inactiveSelectionForeground": "#F3F3F3",
         "list.inactiveSelectionBackground": "#44403C",
-        "minimap.background": "#292524",
+        "minimap.background": "#12100C",
         "minimapSlider.activeBackground": "#44403C",
         "tab.inactiveBackground": "#1C1917",
         "editor.selectionBackground": "#A35800",

--- a/extensions/theme-defaults/themes/gitpod-dark-color-theme.json
+++ b/extensions/theme-defaults/themes/gitpod-dark-color-theme.json
@@ -2,12 +2,27 @@
 	"name": "Gitpod Dark",
 	"include": "./dark_plus.json",
 	"colors": {
-		"statusBarItem.remoteBackground": "#292524",
+		"statusBarItem.remoteBackground": "#D67400",
         "statusBarItem.remoteForeground": "#f9f9f9",
-        "statusBar.background": "#FF8A00",
-        "statusBar.noFolderBackground": "#FF8A00",
-        "statusBar.debuggingBackground": "#FF8A00",
-        "button.background": "#FF8A00",
-        "button.foreground": "#ffffff"
+        "statusBar.background": "#252526",
+        "statusBar.foreground": "#F3F3F3",
+        "statusBar.noFolderBackground": "#D67400",
+        "statusBar.debuggingBackground": "#D67400",
+        "sideBar.background": "#1C1917",
+        "sideBarSectionHeader.background": "#252526",
+        "activityBar.background": "#292524",
+        "activityBar.foreground": "#F3F3F3",
+        "editor.background": "#292524",
+        "button.background": "#D67400",
+        "button.foreground": "#ffffff",
+        "list.activeSelectionBackground": "#57534E",
+        "list.activeSelectionForeground": "#F3F3F3",
+        "list.inactiveSelectionForeground": "#F3F3F3",
+        "list.inactiveSelectionBackground": "#44403C",
+        "minimap.background": "#292524",
+        "minimapSlider.activeBackground": "#44403C",
+        "tab.inactiveBackground": "#1C1917",
+        "editor.selectionBackground": "#A35800",
+        "editor.inactiveSelectionBackground": "#7A4200"
 	}
 }

--- a/extensions/theme-defaults/themes/gitpod-dark-color-theme.json
+++ b/extensions/theme-defaults/themes/gitpod-dark-color-theme.json
@@ -12,7 +12,7 @@
         "sideBarSectionHeader.background": "#252526",
         "activityBar.background": "#292524",
         "activityBar.foreground": "#F3F3F3",
-        "editor.background": "#292524",
+        "editor.background": "#12100C",
         "button.background": "#D67400",
         "button.foreground": "#ffffff",
         "list.activeSelectionBackground": "#57534E",


### PR DESCRIPTION
This will update the Gitpod Dark theme according to the recent update of the Gitpod Light theme in https://github.com/gitpod-io/vscode/pull/15.

| BEFORE | AFTER |
|-|-|
| ![dark-before](https://user-images.githubusercontent.com/120486/113201867-b5dcb700-9272-11eb-98a6-e14e0e959c80.png) |  ![image](https://user-images.githubusercontent.com/120486/113201870-b7a67a80-9272-11eb-93bb-88aa3672a9bb.png) |