### PR TITLE
Use absolute paths in the startup script

### DIFF
--- a/resources/server/startup.sh
+++ b/resources/server/startup.sh
@@ -1,2 +1,10 @@
 #!/bin/bash
-exec ./node/bin/node ./server-pkg/out/server.js "$@"
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+	realpath() { [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"; }
+	ROOT=$(dirname "$(realpath "$0")")
+else
+	ROOT=$(dirname "$(readlink -f $0)")
+fi
+
+exec $ROOT/node/bin/node $ROOT/server-pkg/out/server.js "$@"


### PR DESCRIPTION
Use Node and entry point from their respective absolute paths in the file system.